### PR TITLE
PAPI-58: remove hardcoded version and add php ^7.4 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # PAPI
 
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/aryeo/papi.svg?style=flat-square)](https://packagist.org/packages/aryeo/papi)
+[![Total Downloads](https://img.shields.io/packagist/dt/aryeo/papi.svg?style=flat-square)](https://packagist.org/packages/aryeo/papi)
+
 A suite of tools for spec-driven API development in Laravel.
 
 ## Installation
 
 ```bash
-composer require aryeohq/papi
+composer require aryeo/papi --dev
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "aryeo/papi",
   "description": "Powerful API (PAPI) utilities.",
-  "version": "1.0.0",
   "type": "library",
   "keywords": [
     "cli",
@@ -35,6 +34,7 @@
     }
   },
   "require": {
+    "php": "^7.4",
     "minicli/minicli": "^2.0"
   },
   "bin": [


### PR DESCRIPTION
## Enhancement
- Remove hardcoded version in `composer.json` to allow packagist to resolve this from release tags.
- Add PHP "^7.4" as dependency.
- Update README.md with packagist badges and new package location.