### PR TITLE
Add optional public customizations file

### DIFF
--- a/app/Command/Clean/ModelsController.php
+++ b/app/Command/Clean/ModelsController.php
@@ -13,7 +13,7 @@ class ModelsController extends PapiController
         parent::boot($app);
         $this->description = 'clean models';
         $this->parameters = [
-            ['m_dir', 'models directory', '/examples/models'],
+            ['m_dir', 'models directory', '/examples/models', true],
         ];
         $this->notes = [
             'Cleaning models applies known defaults to models that',

--- a/app/Command/Clean/SpecController.php
+++ b/app/Command/Clean/SpecController.php
@@ -13,9 +13,9 @@ class SpecController extends PapiController
         parent::boot($app);
         $this->description = 'clean a spec file';
         $this->parameters = [
-            ['s_path', 'path to spec file', '/examples/reference/PetStore/PetStore.2021-07-23.json'],
-            ['r_path', 'path to responses JSON file', '/examples/responses.json'],
-            ['rm_path', 'path to response mappings JSON file', '/examples/response-mappings.json']
+            ['s_path', 'path to spec file', '/examples/reference/PetStore/PetStore.2021-07-23.json', true],
+            ['r_path', 'path to responses JSON file', '/examples/responses.json', true],
+            ['rm_path', 'path to response mappings JSON file', '/examples/response-mappings.json', true]
         ];
         $this->notes = [
             'Cleaning a spec inserts standard error responses for known status',
@@ -40,17 +40,17 @@ class SpecController extends PapiController
 
     public function cleanSpec($spec_file_path, $responses_path, $response_mappings_path)
     {
-        if (!PapiMethods::isValidFile($spec_file_path)) {
+        if (!PapiMethods::validPath($spec_file_path)) {
             $this->printFileNotFound($spec_file_path);
             return;
         }
 
-        if (!PapiMethods::isValidFile($responses_path)) {
+        if (!PapiMethods::validPath($responses_path)) {
             $this->printFileNotFound($responses_path);
             return;
         }
 
-        if (!PapiMethods::isValidFile($response_mappings_path)) {
+        if (!PapiMethods::validPath($response_mappings_path)) {
             $this->printFileNotFound($response_mappings_path);
             return;
         }

--- a/app/Command/Make/MergeController.php
+++ b/app/Command/Make/MergeController.php
@@ -13,10 +13,10 @@ class MergeController extends PapiController
         parent::boot($app);
         $this->description = 'make a merged api spec by squashing versions together';
         $this->parameters = [
-            ['s_dir', 'spec directory', '/examples/reference/PetStore'],
-            ['s_prefix', 'spec prefix', 'PetStore (e.g. PetStore.2021-07-23.json)'],
-            ['version', 'highest version to include in the merge', '2021-07-23'],
-            ['out_path', 'write path for merged api spec', '/examples/out/PetStore/PetStore.MERGED.json'],
+            ['s_dir', 'spec directory', '/examples/reference/PetStore', true],
+            ['s_prefix', 'spec prefix', 'PetStore (e.g. PetStore.2021-07-23.json)', true],
+            ['version', 'highest version to include in the merge', '2021-07-23', true],
+            ['out_path', 'write path for merged api spec', '/examples/out/PetStore/PetStore.MERGED.json', true],
         ];
         $this->notes = [
             'When API versions are merged together, the most recent version of',
@@ -42,10 +42,8 @@ class MergeController extends PapiController
     public function mergeVersions($spec_dir, $spec_prefix, $version, $out_path)
     {
         $version_file_path = $spec_dir . DIRECTORY_SEPARATOR . $spec_prefix . '.' . $version . '.json';
-        if (!PapiMethods::isValidFile($version_file_path)) {
-            $this->getPrinter()->out('👎 FAIL: Unable to find spec file for highest version.', 'error');
-            $this->getPrinter()->newline();
-            $this->getPrinter()->newline();
+        if (!PapiMethods::validPath($version_file_path)) {
+            $this->printFileNotFound($version_file_path);
             return;
         }
 

--- a/app/Command/Make/TestsController.php
+++ b/app/Command/Make/TestsController.php
@@ -13,9 +13,9 @@ class TestsController extends PapiController
         parent::boot($app);
         $this->description = 'make missing spec tests given an api spec';
         $this->parameters = [
-            ['p_dir', 'project directory', '/examples/stubbed-laravel-project'],
-            ['s_dir', 'spec directory', '/examples/reference/PetStore'],
-            ['t_path', 'path to test template', '/examples/TemplateTest.php']
+            ['p_dir', 'project directory', '/examples/stubbed-laravel-project', true],
+            ['s_dir', 'spec directory', '/examples/reference/PetStore', true],
+            ['t_path', 'path to test template', '/examples/TemplateTest.php', true]
         ];
         $this->notes = ['Tests will be created in the [p_dir]/tests/Spec directory.'];
     }

--- a/app/Command/PapiController.php
+++ b/app/Command/PapiController.php
@@ -182,8 +182,27 @@ class PapiController extends CommandController
     public function printParameters()
     {
         if (count($this->parameters) > 0) {
+            $required_parameters = array_filter($this->parameters, function ($parameter) {
+                return $parameter[3];
+            });
+
+            $optional_parameters = array_filter($this->parameters, function ($parameter) {
+                return !$parameter[3];
+            });
+
             $this->getPrinter()->out('Parameters', 'bold');
-            foreach ($this->parameters as $parameter) {
+            foreach ($required_parameters as $parameter) {
+                $this->getPrinter()->newline();
+                $this->getPrinter()->out('  '.str_pad($parameter[0], 10, ' ', STR_PAD_RIGHT), 'success');
+                $this->getPrinter()->rawOutput("\t".$parameter[1]);
+                if (!empty($parameter[2])) {
+                    $this->getPrinter()->out(' [ex: '.$parameter[2].']', 'info');
+                }
+            }
+            $this->printSectionEnd();
+
+            $this->getPrinter()->out('Optional Parameters', 'bold');
+            foreach ($optional_parameters as $parameter) {
                 $this->getPrinter()->newline();
                 $this->getPrinter()->out('  '.str_pad($parameter[0], 10, ' ', STR_PAD_RIGHT), 'success');
                 $this->getPrinter()->rawOutput("\t".$parameter[1]);
@@ -264,7 +283,7 @@ class PapiController extends CommandController
 
         $proper_params = true;
         foreach ($this->parameters as $parameter) {
-            if (!$this->hasParam($parameter[0])) {
+            if (!$this->hasParam($parameter[0]) && $parameter[3]) {
                 $proper_params = false;
                 break;
             }

--- a/app/Command/Report/DiffController.php
+++ b/app/Command/Report/DiffController.php
@@ -13,11 +13,11 @@ class DiffController extends PapiController
         parent::boot($app);
         $this->description = 'report the differences between two versions of an API';
         $this->parameters = [
-            ['s_dir', 'spec directory', '/examples/reference/PetStore'],
-            ['s_prefix', 'spec prefix', 'PetStore (e.g. PetStore.2021-07-23.json)'],
-            ['m_dir', 'models directory', '/examples/models'],
-            ['old_version', 'spec version that comes before new_version', '2021-07-23'],
-            ['new_version', 'spec version that comes after old_version', '2021-07-24'],
+            ['s_dir', 'spec directory', '/examples/reference/PetStore', true],
+            ['s_prefix', 'spec prefix', 'PetStore (e.g. PetStore.2021-07-23.json)', true],
+            ['m_dir', 'models directory', '/examples/models', true],
+            ['old_version', 'spec version that comes before new_version', '2021-07-23', true],
+            ['new_version', 'spec version that comes after old_version', '2021-07-24', true]
         ];
     }
 

--- a/app/Command/Report/RefsController.php
+++ b/app/Command/Report/RefsController.php
@@ -15,8 +15,8 @@ class RefsController extends PapiController
         parent::boot($app);
         $this->description = 'report out-of-date refs';
         $this->parameters = [
-            ['s_path', 'path to spec file', '/examples/reference/PetStore/PetStore.2021-07-23.json'],
-            ['m_dir', 'models directory', '/examples/models']
+            ['s_path', 'path to spec file', '/examples/reference/PetStore/PetStore.2021-07-23.json', true],
+            ['m_dir', 'models directory', '/examples/models', true]
         ];
     }
 

--- a/app/Command/Report/SafeController.php
+++ b/app/Command/Report/SafeController.php
@@ -14,8 +14,8 @@ class SafeController extends PapiController
         parent::boot($app);
         $this->description = 'check if changes to an api are safe';
         $this->parameters = [
-            ['l_spec', 'path to last spec reference', '/examples/out/PetStore/PetStore.LAST.json'],
-            ['c_spec', 'path to current spec reference', '/examples/out/PetStore/PetStore.CURRENT.json'],
+            ['l_spec', 'path to last spec reference', '/examples/out/PetStore/PetStore.LAST.json', true],
+            ['c_spec', 'path to current spec reference', '/examples/out/PetStore/PetStore.CURRENT.json', true],
         ];
     }
 

--- a/app/Methods/PapiMethods.php
+++ b/app/Methods/PapiMethods.php
@@ -11,7 +11,7 @@ class PapiMethods
      * Files
      */
 
-    public static function isValidFile($path)
+    public static function validPath(string $path): bool
     {
         return !(empty($path) || !file_exists($path) || !is_file($path));
     }

--- a/examples/public.json
+++ b/examples/public.json
@@ -1,0 +1,5 @@
+{
+    "strip-path-parameters": [
+        "api_key"
+    ]
+}


### PR DESCRIPTION
Adds support for public customizations file. This same file can be used for future extensions and overrides related to private-->public spec transformations.