### PR TITLE
Update Github actions to run tests against PHP 8

### DIFF
--- a/.github/workflows/run-phpunit-tests.yml
+++ b/.github/workflows/run-phpunit-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.4"
+          php-version: "8.0"
           coverage: none
 
       - name: Checkout code


### PR DESCRIPTION
- Jump to PHP 8
- PHP-8: Run tests in PHP 8
