### PR TITLE
Replace simple associate arrays with cebe/openapi abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ vendor/
 composer.lock
 *.DS_Store
 examples/out
+examples/models/2021-06-17
 .phpunit.result.cache

--- a/app/Command/Make/MergeController.php
+++ b/app/Command/Make/MergeController.php
@@ -21,7 +21,7 @@ class MergeController extends PapiController
         ];
         $this->notes = [
             'When API versions are merged together, the most recent version of',
-            'each named route and method combination are used.',
+            'each named operation and method combination are used.',
         ];
     }
 

--- a/app/Command/Make/PublicController.php
+++ b/app/Command/Make/PublicController.php
@@ -11,7 +11,7 @@ class PublicController extends PapiController
     public function boot(App $app)
     {
         parent::boot($app);
-        $this->description = 'make public api spec from a de-referenced spec';
+        $this->description = 'make public api spec from a non-public spec';
         $this->parameters = [
             ['format', 'spec format, defaults to JSON (JSON|YAML)', 'JSON', false],
             ['s_path', 'path to spec file', '/examples/out/PetStore/PetStore.MERGED.json', true],

--- a/app/Command/Report/DiffController.php
+++ b/app/Command/Report/DiffController.php
@@ -46,27 +46,27 @@ class DiffController extends PapiController
 
             return;
         } else {
-            $this->compareRoutes($spec_dir, $spec_prefix, $old_version, $new_version);
+            $this->compareOperations($spec_dir, $spec_prefix, $old_version, $new_version);
             $this->compareModels($spec_dir, $models_dir, $old_version, $new_version);
         }
     }
 
-    public function compareRoutes($spec_dir, $spec_prefix, $old_version, $new_version)
+    public function compareOperations($spec_dir, $spec_prefix, $old_version, $new_version)
     {
-        // gather routes in specs less than or equal to $old_version
+        // gather operations in specs less than or equal to $old_version
         $older_versions = PapiMethods::versionsEqualToOrBelow($spec_dir, $old_version, $this->getFormat());
-        $older_routes = $this->gatherRoutesForVersions($spec_dir, $spec_prefix, $older_versions);
+        $older_operations = $this->gatherOperationsForVersions($spec_dir, $spec_prefix, $older_versions);
         
-        // gather routes in specs newer than $old_version, but less than $new_version
+        // gather operations in specs newer than $old_version, but less than $new_version
         $newer_versions = PapiMethods::versionsBetween($spec_dir, $old_version, false, $new_version, true, $this->getFormat());
-        $newer_routes = $this->gatherRoutesForVersions($spec_dir, $spec_prefix, $newer_versions);
+        $newer_operations = $this->gatherOperationsForVersions($spec_dir, $spec_prefix, $newer_versions);
         
-        $this->showDiff('ROUTES', $older_routes, $newer_routes);
+        $this->showDiff('ROUTES', $older_operations, $newer_operations);
     }
 
-    public function gatherRoutesForVersions($spec_dir, $spec_name, $versions)
+    public function gatherOperationsForVersions($spec_dir, $spec_name, $versions)
     {
-        $routes = [];
+        $operations = [];
 
         $format = $this->getFormat();
         $valid_extensions = PapiMethods::validExtensions($format);
@@ -81,11 +81,11 @@ class DiffController extends PapiController
                 }
             }
 
-            $v_routes = PapiMethods::routes($spec_file_path);
-            $routes = array_merge($v_routes, $routes);
+            $v_operations = PapiMethods::operationsKeys($spec_file_path);
+            $operations = array_merge($v_operations, $operations);
         }
 
-        return $routes;
+        return $operations;
     }
 
     public function compareModels($spec_dir, $models_dir, $old_version, $new_version)

--- a/app/Command/Report/SafeController.php
+++ b/app/Command/Report/SafeController.php
@@ -34,19 +34,19 @@ class SafeController extends PapiController
 
     public function checkSpecs($current_spec_path, $last_spec_path)
     {
-        $last_array = PapiMethods::readSpecFile($last_spec_path);
-
-        if ($last_array === false) {
+        // open last api spec
+        $last_open_api = PapiMethods::readSpecFileToOpenApi($last_spec_path);
+        if ($last_open_api === null) {
             $this->safetyHeader();
             $this->getPrinter()->out('👎 FAIL: Unable to open last spec.', 'error');
             $this->getPrinter()->newline();
             $this->getPrinter()->newline();
             exit(-1);
         }
-
-        $current_array = PapiMethods::readSpecFile($current_spec_path);
-
-        if ($current_array === false) {
+        
+        // open current api spec
+        $current_open_api = PapiMethods::readSpecFileToOpenApi($current_spec_path);
+        if ($current_open_api === null) {
             $this->safetyHeader();
             $this->getPrinter()->out('👎 FAIL: Unable to open current spec.', 'error');
             $this->getPrinter()->newline();
@@ -54,17 +54,8 @@ class SafeController extends PapiController
             exit(-1);
         }
 
-        $last_array_version = '';
-        if (isset($last_array['info'])) {
-            $last_array_version = $last_array['info']['version'];
-        }
-
-        $current_array_version = '';
-        if (isset($current_array['info'])) {
-            $current_array_version = $current_array['info']['version'];
-        }
-
-        if ($last_array_version !== $current_array_version) {
+        // ensure we are checking specs with same version
+        if ($last_open_api->info->version !== $current_open_api->info->version) {
             $this->safetyHeader();
             $this->getPrinter()->rawOutput('Specs being compared are not the same version. Exiting quietly.', 'error');
             $this->getPrinter()->newline();
@@ -75,29 +66,29 @@ class SafeController extends PapiController
         $section_results = [];
 
         // additions...
-        $section_results[] = $this->checkRouteSecurityAdditions($last_array, $current_array);
+        $section_results[] = $this->checkOperationSecurityAdditions($last_open_api, $current_open_api);
 
         // removals...
-        $section_results[] = $this->checkResponsePropertyRemovals($last_array, $current_array);
-        $section_results[] = $this->checkRequestBodyPropertyRemovals($last_array, $current_array);
-        $section_results[] = $this->checkRouteMethodDirectRemovals($last_array, $current_array);
-        $section_results[] = $this->checkRouteMethodDeprecatedRemovals($last_array, $current_array);
-        $section_results[] = $this->checkRouteMethodInternalRemovals($last_array, $current_array);
-        $section_results[] = $this->checkResponseRemovals($last_array, $current_array);
-        $section_results[] = $this->checkQueryParamRemovals($last_array, $current_array);
-        $section_results[] = $this->checkHeaderRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkResponsePropertyRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkRequestBodyPropertyRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkOperationMethodDirectRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkOperationMethodDeprecatedRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkOperationMethodInternalRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkResponseRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkQueryParamRemovals($last_array, $current_array);
+        // $section_results[] = $this->checkHeaderRemovals($last_array, $current_array);
 
-        // type changes...
-        $section_results[] = $this->checkResponsePropertyTypeChanged($last_array, $current_array);
-        $section_results[] = $this->checkRequestBodyPropertyTypeChanged($last_array, $current_array);
-        $section_results[] = $this->checkQueryParameterTypeChanged($last_array, $current_array);
-        $section_results[] = $this->checkHeaderTypeChanged($last_array, $current_array);
-        $section_results[] = $this->checkEnumsChanged($last_array, $current_array);
+        // // type changes...
+        // $section_results[] = $this->checkResponsePropertyTypeChanged($last_array, $current_array);
+        // $section_results[] = $this->checkRequestBodyPropertyTypeChanged($last_array, $current_array);
+        // $section_results[] = $this->checkQueryParameterTypeChanged($last_array, $current_array);
+        // $section_results[] = $this->checkHeaderTypeChanged($last_array, $current_array);
+        // $section_results[] = $this->checkEnumsChanged($last_array, $current_array);
 
-        // optionality...
-        $section_results[] = $this->checkRequestBodyPropertyNowRequired($last_array, $current_array);
-        $section_results[] = $this->checkQueryParameterNowRequired($last_array, $current_array);
-        $section_results[] = $this->checkHeaderNowRequired($last_array, $current_array);
+        // // optionality...
+        // $section_results[] = $this->checkRequestBodyPropertyNowRequired($last_array, $current_array);
+        // $section_results[] = $this->checkQueryParameterNowRequired($last_array, $current_array);
+        // $section_results[] = $this->checkHeaderNowRequired($last_array, $current_array);
 
         // display results and exit accordingly...
         if ($this->displaySectionResultsWithErrors($section_results)) {
@@ -117,42 +108,48 @@ class SafeController extends PapiController
      * Additions
      */
 
-    public function checkRouteSecurityAdditions($last_array, $current_array)
+    public function checkOperationSecurityAdditions($last_open_api, $current_open_api)
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route = PapiMethods::getNestedValue($last_array, $route_key);
-            $current_route = PapiMethods::getNestedValue($current_array, $route_key);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
+            $last_operation = PapiMethods::getOperation($last_open_api, $operation_key);
+            $current_operation = PapiMethods::getOperation($current_open_api, $operation_key);
 
             // is the security the same?
-            $last_route_security = [];
-            if (isset($last_route['security'])) {
-                foreach ($last_route['security'] as $security_object) {
-                    $last_route_security[] = array_keys($security_object)[0];
-                }
-            }
-            $current_route_security = [];
-            if (isset($current_route['security'])) {
-                foreach ($current_route['security'] as $security_object) {
-                    $current_route_security[] = array_keys($security_object)[0];
+            $last_operation_security = [];
+            if ($last_operation->security) {
+                foreach ($last_operation->security as $security_object) {
+                    foreach ($security_object->getSerializableData() as $security_key => $value) {
+                        $last_operation_security[] = $security_key;
+                    }
                 }
             }
 
-            $diff = array_diff($current_route_security, $last_route_security);
+
+            $current_operation_security = [];
+            if ($current_operation->security) {
+                foreach ($current_operation->security as $security_object) {
+                    foreach ($security_object->getSerializableData() as $security_key => $value) {
+                        $current_operation_security[] = $security_key;
+                    }
+                }
+            }
+
+            $diff = array_diff($current_operation_security, $last_operation_security);
 
             if (count($diff) > 0) {
                 $new_schemes = array_values($diff);
                 $errors[] = sprintf(
-                    '%s: `%s` security has been added to this route.',
-                    PapiMethods::formatRouteKey($route_key),
+                    '%s: `%s` security has been added to this operation.',
+                    PapiMethods::formatOperationKey($operation_key),
                     join(', ', $new_schemes)
                 );
             }
         }
 
-        return new SectionResults('Route Security Additions', $errors);
+        return new SectionResults('Operation Security Additions', $errors);
     }
 
     /*
@@ -163,25 +160,25 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route = PapiMethods::getNestedValue($last_array, $route_key);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation = PapiMethods::getNestedValue($last_array, $operation_key);
 
             // for each response...
-            if (isset($last_route['responses'])) {
-                foreach ($last_route['responses'] as $status_code => $last_route_response) {
-                    $current_route_response = PapiMethods::getNestedValue($current_array, $route_key.'[responses]'.'['.$status_code.']');
+            if (isset($last_operation['responses'])) {
+                foreach ($last_operation['responses'] as $status_code => $last_operation_response) {
+                    $current_operation_response = PapiMethods::getNestedValue($current_array, $operation_key.'[responses]'.'['.$status_code.']');
 
                     // does the current spec have a response for this status code?
-                    if ($current_route_response) {
-                        $last_route_schema = $last_route_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $last_route_response['description'], 'properties' => []];
-                        $current_route_schema = $current_route_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $current_route_response['description'], 'properties' => []];
+                    if ($current_operation_response) {
+                        $last_operation_schema = $last_operation_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $last_operation_response['description'], 'properties' => []];
+                        $current_operation_schema = $current_operation_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $current_operation_response['description'], 'properties' => []];
 
                         // are the properties the same?
                         $error = $this->schemaDiff(
-                            $last_route_schema,
-                            $current_route_schema,
-                            PapiMethods::formatRouteKey($route_key),
+                            $last_operation_schema,
+                            $current_operation_schema,
+                            PapiMethods::formatOperationKey($operation_key),
                             $status_code
                         );
 
@@ -200,19 +197,19 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route_request_body = PapiMethods::getNestedValue($last_array, $route_key.'[requestBody]');
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation_request_body = PapiMethods::getNestedValue($last_array, $operation_key.'[requestBody]');
 
             // was there a request body in last spec?
-            if ($last_route_request_body) {
-                $current_route_request_body = PapiMethods::getNestedValue($current_array, $route_key.'[requestBody]');
+            if ($last_operation_request_body) {
+                $current_operation_request_body = PapiMethods::getNestedValue($current_array, $operation_key.'[requestBody]');
 
                 // if so, has it changed?
                 $error = $this->schemaDiff(
-                    $last_route_request_body['content']['application/json']['schema'],
-                    $current_route_request_body['content']['application/json']['schema'],
-                    PapiMethods::formatRouteKey($route_key),
+                    $last_operation_request_body['content']['application/json']['schema'],
+                    $current_operation_request_body['content']['application/json']['schema'],
+                    PapiMethods::formatOperationKey($operation_key),
                     'Request Body'
                 );
 
@@ -225,57 +222,57 @@ class SafeController extends PapiController
         return new SectionResults('Request Body Property Removals', $errors);
     }
 
-    public function checkRouteMethodDirectRemovals($last_array, $current_array)
+    public function checkOperationMethodDirectRemovals($last_open_api, $current_open_api)
     {
         $errors = [];
 
-        $last_route_keys = array_keys(PapiMethods::routesFromArray($last_array, true));
-        $current_route_keys = array_keys(PapiMethods::routesFromArray($current_array, true));
+        $last_operation_keys = array_keys(PapiMethods::operationKeysFromOpenApi($last_open_api, true));
+        $current_operation_keys = array_keys(PapiMethods::operationKeysFromOpenApi($current_open_api, true));
 
-        $diff = array_diff($last_route_keys, $current_route_keys);
+        $diff = array_diff($last_operation_keys, $current_operation_keys);
 
         if (count($diff) > 0) {
-            foreach ($diff as $route_key) {
-                $errors[] = sprintf('%s: This route has been removed.', PapiMethods::formatRouteKey($route_key));
+            foreach ($diff as $operation_key) {
+                $errors[] = sprintf('%s: This operation has been removed.', PapiMethods::formatOperationKey($operation_key));
             }
         }
 
-        return new SectionResults('Route Removals', $errors);
+        return new SectionResults('Operation Removals', $errors);
     }
 
-    public function checkRouteMethodDeprecatedRemovals($last_array, $current_array)
+    public function checkOperationMethodDeprecatedRemovals($last_array, $current_array)
     {
-        $errors = $this->routeDiff($last_array, $current_array, 'deprecated', 'deprecated');
+        $errors = $this->operationDiff($last_array, $current_array, 'deprecated', 'deprecated');
 
-        return new SectionResults('Routes Marked Deprecated', $errors);
+        return new SectionResults('Operations Marked Deprecated', $errors);
     }
 
-    public function checkRouteMethodInternalRemovals($last_array, $current_array)
+    public function checkOperationMethodInternalRemovals($last_array, $current_array)
     {
-        $errors = $this->routeDiff($last_array, $current_array, 'x-internal', 'internal');
+        $errors = $this->operationDiff($last_array, $current_array, 'x-internal', 'internal');
 
-        return new SectionResults('Routes Marked Internal', $errors);
+        return new SectionResults('Operations Marked Internal', $errors);
     }
 
     public function checkResponseRemovals($last_array, $current_array)
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route_responses = PapiMethods::getNestedValue($last_array, $route_key.'[responses]');
-            $last_route_codes = array_keys($last_route_responses);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation_responses = PapiMethods::getNestedValue($last_array, $operation_key.'[responses]');
+            $last_operation_codes = array_keys($last_operation_responses);
 
-            $current_route_responses = PapiMethods::getNestedValue($current_array, $route_key.'[responses]');
-            $current_route_codes = array_keys($current_route_responses);
+            $current_operation_responses = PapiMethods::getNestedValue($current_array, $operation_key.'[responses]');
+            $current_operation_codes = array_keys($current_operation_responses);
 
-            $diff = array_diff($last_route_codes, $current_route_codes);
+            $diff = array_diff($last_operation_codes, $current_operation_codes);
 
             if (count($diff) > 0) {
                 foreach ($diff as $status_code) {
                     $errors[] = sprintf(
                         '%s (%s): This response has been removed.',
-                        PapiMethods::formatRouteKey($route_key),
+                        PapiMethods::formatOperationKey($operation_key),
                         $status_code,
                     );
                 }
@@ -289,10 +286,10 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
             // do the query parameters match?
-            $error = $this->routeParametersDiff($last_array, $current_array, $route_key, 'query');
+            $error = $this->operationParametersDiff($last_array, $current_array, $operation_key, 'query');
             if ($error) {
                 $errors[] = $error;
             }
@@ -305,10 +302,10 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
             // do the headers match?
-            $error = $this->routeParametersDiff($last_array, $current_array, $route_key, 'header');
+            $error = $this->operationParametersDiff($last_array, $current_array, $operation_key, 'header');
             if ($error) {
                 $errors[] = $error;
             }
@@ -325,24 +322,24 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route = PapiMethods::getNestedValue($last_array, $route_key);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation = PapiMethods::getNestedValue($last_array, $operation_key);
 
             // for each response...
-            foreach ($last_route['responses'] as $status_code => $last_route_response) {
-                $current_route_response = PapiMethods::getNestedValue($current_array, $route_key.'[responses]'.'['.$status_code.']');
+            foreach ($last_operation['responses'] as $status_code => $last_operation_response) {
+                $current_operation_response = PapiMethods::getNestedValue($current_array, $operation_key.'[responses]'.'['.$status_code.']');
 
                 // does the current spec have a response for this status code?
-                if ($current_route_response) {
-                    $last_route_schema = $last_route_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $last_route_response['description'], 'properties' => []];
-                    $current_route_schema = $current_route_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $current_route_response['description'], 'properties' => []];
+                if ($current_operation_response) {
+                    $last_operation_schema = $last_operation_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $last_operation_response['description'], 'properties' => []];
+                    $current_operation_schema = $current_operation_response['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $current_operation_response['description'], 'properties' => []];
 
                     // are the types the same?
                     $diff_errors = $this->schemaPropertyTypeDiff(
-                        $last_route_schema,
-                        $current_route_schema,
-                        PapiMethods::formatRouteKey($route_key),
+                        $last_operation_schema,
+                        $current_operation_schema,
+                        PapiMethods::formatOperationKey($operation_key),
                         $status_code
                     );
 
@@ -358,19 +355,19 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route = PapiMethods::getNestedValue($last_array, $route_key);
-            $current_route = PapiMethods::getNestedValue($current_array, $route_key);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation = PapiMethods::getNestedValue($last_array, $operation_key);
+            $current_operation = PapiMethods::getNestedValue($current_array, $operation_key);
 
-            $last_route_schema = $last_route['requestBody']['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $route_key, 'properties' => []];
-            $current_route_schema = $current_route['requestBody']['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $route_key, 'properties' => []];
+            $last_operation_schema = $last_operation['requestBody']['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $operation_key, 'properties' => []];
+            $current_operation_schema = $current_operation['requestBody']['content']['application/json']['schema'] ?? ['type' => 'object', 'title' => $operation_key, 'properties' => []];
 
             // are the request body property types the same?
             $diff_errors = $this->schemaPropertyTypeDiff(
-                $last_route_schema,
-                $current_route_schema,
-                PapiMethods::formatRouteKey($route_key),
+                $last_operation_schema,
+                $current_operation_schema,
+                PapiMethods::formatOperationKey($operation_key),
                 'Request Body'
             );
 
@@ -384,13 +381,13 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
             // are the query parameter types the same?
-            $diff_errors = $this->routeParametersTypeDiff(
+            $diff_errors = $this->operationParametersTypeDiff(
                 $last_array,
                 $current_array,
-                $route_key,
+                $operation_key,
                 'query',
                 '[schema][type]'
             );
@@ -405,13 +402,13 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
             // are the header types the same?
-            $diff_errors = $this->routeParametersTypeDiff(
+            $diff_errors = $this->operationParametersTypeDiff(
                 $last_array,
                 $current_array,
-                $route_key,
+                $operation_key,
                 'header',
                 '[schema][type]'
             );
@@ -426,31 +423,31 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route = PapiMethods::getNestedValue($last_array, $route_key);
-            $current_route = PapiMethods::getNestedValue($current_array, $route_key);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation = PapiMethods::getNestedValue($last_array, $operation_key);
+            $current_operation = PapiMethods::getNestedValue($current_array, $operation_key);
 
             // for each response...
-            if (isset($last_route['responses'])) {
-                foreach ($last_route['responses'] as $status_code => $last_route_response) {
-                    $current_route_response = PapiMethods::getNestedValue($current_array, $route_key.'[responses]'.'['.$status_code.']');
+            if (isset($last_operation['responses'])) {
+                foreach ($last_operation['responses'] as $status_code => $last_operation_response) {
+                    $current_operation_response = PapiMethods::getNestedValue($current_array, $operation_key.'[responses]'.'['.$status_code.']');
 
                     // for each enum in the response...
-                    foreach (PapiMethods::arrayFindRecursive($last_route_response, 'enum') as $result) {
+                    foreach (PapiMethods::arrayFindRecursive($last_operation_response, 'enum') as $result) {
                         $enum_path = $result['path'];
                         $enum_value = $result['value'];
 
                         // does current_array also have this enum?
-                        if ($current_route_response) {
-                            $current_enum_value = PapiMethods::getNestedValue($current_route_response, $enum_path);
+                        if ($current_operation_response) {
+                            $current_enum_value = PapiMethods::getNestedValue($current_operation_response, $enum_path);
                             if ($current_enum_value) {
                                 // has the enum changed?
                                 $diff = array_diff($enum_value, $current_enum_value);
                                 if (count($diff) > 0) {
                                     $errors[] = sprintf(
                                         '%s (%s): Enum mismatch at `%s`.',
-                                        PapiMethods::formatRouteKey($route_key),
+                                        PapiMethods::formatOperationKey($operation_key),
                                         $status_code,
                                         PapiMethods::formatEnumKey($enum_path),
                                     );
@@ -461,29 +458,29 @@ class SafeController extends PapiController
                 }
             }
 
-            // for each route parameter...
-            if (isset($last_route['parameters'])) {
-                foreach (PapiMethods::arrayFindRecursive($last_route['parameters'], 'enum') as $result) {
+            // for each operation parameter...
+            if (isset($last_operation['parameters'])) {
+                foreach (PapiMethods::arrayFindRecursive($last_operation['parameters'], 'enum') as $result) {
                     $enum_path = $result['path'];
 
                     $trimmed_key = substr($enum_path, 1, -1);
                     $parts = explode('][', $trimmed_key);
                     $parameter_index = $parts[0];
-                    $parameter_name = $last_route['parameters'][$parameter_index]['name'];
-                    $parameter_in = $last_route['parameters'][$parameter_index]['in'];
+                    $parameter_name = $last_operation['parameters'][$parameter_index]['name'];
+                    $parameter_in = $last_operation['parameters'][$parameter_index]['in'];
 
                     $enum_value = $result['value'];
 
                     // does current_array also have this enum?
-                    if ($current_route) {
-                        $current_enum_value = PapiMethods::getNestedValue($current_route['parameters'], $enum_path);
+                    if ($current_operation) {
+                        $current_enum_value = PapiMethods::getNestedValue($current_operation['parameters'], $enum_path);
                         if ($current_enum_value) {
                             // has the enum changed?
                             $diff = array_diff($enum_value, $current_enum_value);
                             if (count($diff) > 0) {
                                 $errors[] = sprintf(
                                     '%s (%s): Enum mismatch for %s.',
-                                    PapiMethods::formatRouteKey($route_key),
+                                    PapiMethods::formatOperationKey($operation_key),
                                     'parameter::'.$parameter_in,
                                     $parameter_name,
                                 );
@@ -505,18 +502,18 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $last_route = PapiMethods::getNestedValue($last_array, $route_key);
-            $current_route = PapiMethods::getNestedValue($current_array, $route_key);
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $last_operation = PapiMethods::getNestedValue($last_array, $operation_key);
+            $current_operation = PapiMethods::getNestedValue($current_array, $operation_key);
 
-            $last_route_schema = $last_route['requestBody']['content']['application/json']['schema'] ?? ['type' => 'blank'];
-            $current_route_schema = $current_route['requestBody']['content']['application/json']['schema'] ?? ['type' => 'blank'];
+            $last_operation_schema = $last_operation['requestBody']['content']['application/json']['schema'] ?? ['type' => 'blank'];
+            $current_operation_schema = $current_operation['requestBody']['content']['application/json']['schema'] ?? ['type' => 'blank'];
 
             $diff_errors = $this->schemaPropertyRequiredDiff(
-                $last_route_schema,
-                $current_route_schema,
-                PapiMethods::formatRouteKey($route_key),
+                $last_operation_schema,
+                $current_operation_schema,
+                PapiMethods::formatOperationKey($operation_key),
             );
 
             $errors = array_merge($errors, $diff_errors);
@@ -529,12 +526,12 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $diff_errors = $this->routeParametersRequiredDiff(
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $diff_errors = $this->operationParametersRequiredDiff(
                 $last_array,
                 $current_array,
-                $route_key,
+                $operation_key,
                 'query',
                 '[required]'
             );
@@ -549,12 +546,12 @@ class SafeController extends PapiController
     {
         $errors = [];
 
-        // for matching routes...
-        foreach (PapiMethods::matchingRouteKeys($last_array, $current_array) as $route_key) {
-            $diff_errors = $this->routeParametersRequiredDiff(
+        // for matching operations...
+        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+            $diff_errors = $this->operationParametersRequiredDiff(
                 $last_array,
                 $current_array,
-                $route_key,
+                $operation_key,
                 'header',
                 '[required]'
             );
@@ -708,47 +705,47 @@ class SafeController extends PapiController
         return $errors;
     }
 
-    public function routeParametersDiff($a_array, $b_array, $route_key, $parameter_type)
+    public function operationParametersDiff($a_array, $b_array, $operation_key, $parameter_type)
     {
-        // routeParameters returns an array with format... ['PARAM_NAME' => 'value', ...]
-        $a_route_query_parameters = array_values(
-            $this->routeParameters($a_array, $route_key, $parameter_type, '[name]')
+        // operationParameters returns an array with format... ['PARAM_NAME' => 'value', ...]
+        $a_operation_query_parameters = array_values(
+            $this->operationParameters($a_array, $operation_key, $parameter_type, '[name]')
         );
-        $b_route_query_parameters = array_values(
-            $this->routeParameters($b_array, $route_key, $parameter_type, '[name]')
+        $b_operation_query_parameters = array_values(
+            $this->operationParameters($b_array, $operation_key, $parameter_type, '[name]')
         );
-        $diff = array_diff($a_route_query_parameters, $b_route_query_parameters);
+        $diff = array_diff($a_operation_query_parameters, $b_operation_query_parameters);
 
         if (count($diff) > 0) {
             return sprintf(
                 '%s: `%s` has been removed.',
-                PapiMethods::formatRouteKey($route_key),
+                PapiMethods::formatOperationKey($operation_key),
                 join(', ', $diff)
             );
         }
     }
 
-    public function routeParametersTypeDiff($a_array, $b_array, $route_key, $param_in, $param_value_key)
+    public function operationParametersTypeDiff($a_array, $b_array, $operation_key, $param_in, $param_value_key)
     {
         $errors = [];
 
-        // routeParameters returns an array with format... ['PARAM_NAME' => 'value', ...]
-        $a_route_params = $this->routeParameters($a_array, $route_key, $param_in, $param_value_key);
-        $b_route_params = $this->routeParameters($b_array, $route_key, $param_in, $param_value_key);
+        // operationParameters returns an array with format... ['PARAM_NAME' => 'value', ...]
+        $a_operation_params = $this->operationParameters($a_array, $operation_key, $param_in, $param_value_key);
+        $b_operation_params = $this->operationParameters($b_array, $operation_key, $param_in, $param_value_key);
 
         // for each param...
-        foreach ($a_route_params as $a_route_param_key => $a_route_param_value) {
-            if (isset($b_route_params[$a_route_param_key])) {
-                $b_route_param_value = $b_route_params[$a_route_param_key];
+        foreach ($a_operation_params as $a_operation_param_key => $a_operation_param_value) {
+            if (isset($b_operation_params[$a_operation_param_key])) {
+                $b_operation_param_value = $b_operation_params[$a_operation_param_key];
 
-                if ($b_route_param_value) {
-                    if (strcmp($a_route_param_value, $b_route_param_value) !== 0) {
+                if ($b_operation_param_value) {
+                    if (strcmp($a_operation_param_value, $b_operation_param_value) !== 0) {
                         $errors[] = sprintf(
                             '%s: Type mismatch (`%s`|`%s`) for `%s`.',
-                            PapiMethods::formatRouteKey($route_key),
-                            $a_route_param_value,
-                            $b_route_param_value,
-                            $a_route_param_key,
+                            PapiMethods::formatOperationKey($operation_key),
+                            $a_operation_param_value,
+                            $b_operation_param_value,
+                            $a_operation_param_key,
                         );
                     }
                 }
@@ -758,25 +755,25 @@ class SafeController extends PapiController
         return $errors;
     }
 
-    public function routeParametersRequiredDiff($a_array, $b_array, $route_key, $param_in, $param_value_key)
+    public function operationParametersRequiredDiff($a_array, $b_array, $operation_key, $param_in, $param_value_key)
     {
         $errors = [];
 
-        // routeParameters returns an array with format... ['PARAM_NAME' => 'value', ...]
-        $a_route_params = $this->routeParameters($a_array, $route_key, $param_in, $param_value_key);
-        $b_route_params = $this->routeParameters($b_array, $route_key, $param_in, $param_value_key);
+        // operationParameters returns an array with format... ['PARAM_NAME' => 'value', ...]
+        $a_operation_params = $this->operationParameters($a_array, $operation_key, $param_in, $param_value_key);
+        $b_operation_params = $this->operationParameters($b_array, $operation_key, $param_in, $param_value_key);
 
         // for each param...
-        foreach ($a_route_params as $a_route_param_key => $a_route_param_value) {
-            if (isset($b_route_params[$a_route_param_key])) {
-                $b_route_param_value = $b_route_params[$a_route_param_key];
+        foreach ($a_operation_params as $a_operation_param_key => $a_operation_param_value) {
+            if (isset($b_operation_params[$a_operation_param_key])) {
+                $b_operation_param_value = $b_operation_params[$a_operation_param_key];
 
-                if ($b_route_param_value) {
-                    if (!$a_route_param_value && $b_route_param_value) {
+                if ($b_operation_param_value) {
+                    if (!$a_operation_param_value && $b_operation_param_value) {
                         $errors[] = sprintf(
                             '%s: New required parameter `%s`.',
-                            PapiMethods::formatRouteKey($route_key),
-                            $a_route_param_key,
+                            PapiMethods::formatOperationKey($operation_key),
+                            $a_operation_param_key,
                         );
                     }
                 }
@@ -786,49 +783,49 @@ class SafeController extends PapiController
         return $errors;
     }
 
-    public function routeParameters($array, $route_key, $parameter_type, $parameter_value_key)
+    public function operationParameters($array, $operation_key, $parameter_type, $parameter_value_key)
     {
-        $route_parameters = [];
+        $operation_parameters = [];
 
-        $route_all_parameters = PapiMethods::getNestedValue($array, $route_key.'[parameters]');
-        if ($route_all_parameters) {
-            $route_matching_parameters = array_filter($route_all_parameters, function ($route_parameter) use ($parameter_type) {
-                return $route_parameter['in'] === $parameter_type;
+        $operation_all_parameters = PapiMethods::getNestedValue($array, $operation_key.'[parameters]');
+        if ($operation_all_parameters) {
+            $operation_matching_parameters = array_filter($operation_all_parameters, function ($operation_parameter) use ($parameter_type) {
+                return $operation_parameter['in'] === $parameter_type;
             });
 
-            foreach ($route_matching_parameters as $parameter) {
-                $route_parameters[$parameter['name']] = PapiMethods::getNestedValue($parameter, $parameter_value_key);
+            foreach ($operation_matching_parameters as $parameter) {
+                $operation_parameters[$parameter['name']] = PapiMethods::getNestedValue($parameter, $parameter_value_key);
             }
         }
 
-        return $route_parameters;
+        return $operation_parameters;
     }
 
-    public function routeDiff($a_array, $b_array, $on_property, $subject)
+    public function operationDiff($a_array, $b_array, $on_property, $subject)
     {
         $errors = [];
 
-        $matching_keys = iterator_to_array(PapiMethods::matchingRouteKeys($a_array, $b_array));
+        $matching_keys = iterator_to_array(PapiMethods::matchingOperationKeys($a_array, $b_array));
 
-        $a_routes = array_filter($matching_keys, function ($route_key) use ($a_array, $on_property) {
-            $property_value = PapiMethods::getNestedValue($a_array, $route_key.'['.$on_property.']');
-
-            return $property_value !== true;
-        });
-
-        $b_routes = array_filter($matching_keys, function ($route_key) use ($b_array, $on_property) {
-            $property_value = PapiMethods::getNestedValue($b_array, $route_key.'['.$on_property.']');
+        $a_operations = array_filter($matching_keys, function ($operation_key) use ($a_array, $on_property) {
+            $property_value = PapiMethods::getNestedValue($a_array, $operation_key.'['.$on_property.']');
 
             return $property_value !== true;
         });
 
-        $diff = array_diff($a_routes, $b_routes);
+        $b_operations = array_filter($matching_keys, function ($operation_key) use ($b_array, $on_property) {
+            $property_value = PapiMethods::getNestedValue($b_array, $operation_key.'['.$on_property.']');
+
+            return $property_value !== true;
+        });
+
+        $diff = array_diff($a_operations, $b_operations);
 
         if (count($diff) > 0) {
-            foreach ($diff as $route_key) {
+            foreach ($diff as $operation_key) {
                 $errors[] = sprintf(
-                    '%s: This route has been marked as %s.',
-                    PapiMethods::formatRouteKey($route_key),
+                    '%s: This operation has been marked as %s.',
+                    PapiMethods::formatOperationKey($operation_key),
                     $subject
                 );
             }

--- a/app/Command/Report/SafeController.php
+++ b/app/Command/Report/SafeController.php
@@ -46,7 +46,7 @@ class SafeController extends PapiController
 
         $current_array = PapiMethods::readSpecFile($current_spec_path);
 
-        if ($last_array === false) {
+        if ($current_array === false) {
             $this->safetyHeader();
             $this->getPrinter()->out('👎 FAIL: Unable to open current spec.', 'error');
             $this->getPrinter()->newline();

--- a/app/Command/Report/SafeController.php
+++ b/app/Command/Report/SafeController.php
@@ -72,23 +72,23 @@ class SafeController extends PapiController
         $section_results[] = $this->checkResponsePropertyRemovals($last_open_api, $current_open_api);
         $section_results[] = $this->checkRequestBodyPropertyRemovals($last_open_api, $current_open_api);
         $section_results[] = $this->checkOperationMethodDirectRemovals($last_open_api, $current_open_api);
-        // $section_results[] = $this->checkOperationMethodDeprecatedRemovals($last_array, $current_array);
-        // $section_results[] = $this->checkOperationMethodInternalRemovals($last_array, $current_array);
-        // $section_results[] = $this->checkResponseRemovals($last_array, $current_array);
-        // $section_results[] = $this->checkQueryParamRemovals($last_array, $current_array);
-        // $section_results[] = $this->checkHeaderRemovals($last_array, $current_array);
+        $section_results[] = $this->checkOperationMethodDeprecatedRemovals($last_open_api, $current_open_api);
+        $section_results[] = $this->checkOperationMethodInternalRemovals($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkResponseRemovals($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkQueryParamRemovals($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkHeaderRemovals($last_open_api, $current_open_api);
 
         // // type changes...
-        // $section_results[] = $this->checkResponsePropertyTypeChanged($last_array, $current_array);
-        // $section_results[] = $this->checkRequestBodyPropertyTypeChanged($last_array, $current_array);
-        // $section_results[] = $this->checkQueryParameterTypeChanged($last_array, $current_array);
-        // $section_results[] = $this->checkHeaderTypeChanged($last_array, $current_array);
-        // $section_results[] = $this->checkEnumsChanged($last_array, $current_array);
+        // $section_results[] = $this->checkResponsePropertyTypeChanged($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkRequestBodyPropertyTypeChanged($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkQueryParameterTypeChanged($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkHeaderTypeChanged($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkEnumsChanged($last_open_api, $current_open_api);
 
         // // optionality...
-        // $section_results[] = $this->checkRequestBodyPropertyNowRequired($last_array, $current_array);
-        // $section_results[] = $this->checkQueryParameterNowRequired($last_array, $current_array);
-        // $section_results[] = $this->checkHeaderNowRequired($last_array, $current_array);
+        // $section_results[] = $this->checkRequestBodyPropertyNowRequired($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkQueryParameterNowRequired($last_open_api, $current_open_api);
+        // $section_results[] = $this->checkHeaderNowRequired($last_open_api, $current_open_api);
 
         // display results and exit accordingly...
         if ($this->displaySectionResultsWithErrors($section_results)) {
@@ -237,30 +237,30 @@ class SafeController extends PapiController
         return new SectionResults('Operation Removals', $errors);
     }
 
-    public function checkOperationMethodDeprecatedRemovals($last_array, $current_array)
+    public function checkOperationMethodDeprecatedRemovals($last_open_api, $current_open_api)
     {
-        $errors = $this->operationDiff($last_array, $current_array, 'deprecated', 'deprecated');
+        $errors = $this->operationDiff($last_open_api, $current_open_api, 'deprecated', 'deprecated');
 
         return new SectionResults('Operations Marked Deprecated', $errors);
     }
 
-    public function checkOperationMethodInternalRemovals($last_array, $current_array)
+    public function checkOperationMethodInternalRemovals($last_open_api, $current_open_api)
     {
-        $errors = $this->operationDiff($last_array, $current_array, 'x-internal', 'internal');
+        $errors = $this->operationDiff($last_open_api, $current_open_api, 'x-internal', 'internal');
 
         return new SectionResults('Operations Marked Internal', $errors);
     }
 
-    public function checkResponseRemovals($last_array, $current_array)
+    public function checkResponseRemovals($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
-            $last_operation_responses = PapiMethods::getNestedValue($last_array, $operation_key.'[responses]');
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
+            $last_operation_responses = PapiMethods::getNestedValue($last_open_api, $operation_key.'[responses]');
             $last_operation_codes = array_keys($last_operation_responses);
 
-            $current_operation_responses = PapiMethods::getNestedValue($current_array, $operation_key.'[responses]');
+            $current_operation_responses = PapiMethods::getNestedValue($current_open_api, $operation_key.'[responses]');
             $current_operation_codes = array_keys($current_operation_responses);
 
             $diff = array_diff($last_operation_codes, $current_operation_codes);
@@ -279,14 +279,14 @@ class SafeController extends PapiController
         return new SectionResults('Response Removals', $errors);
     }
 
-    public function checkQueryParamRemovals($last_array, $current_array)
+    public function checkQueryParamRemovals($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
             // do the query parameters match?
-            $error = $this->operationParametersDiff($last_array, $current_array, $operation_key, 'query');
+            $error = $this->operationParametersDiff($last_open_api, $current_open_api, $operation_key, 'query');
             if ($error) {
                 $errors[] = $error;
             }
@@ -295,14 +295,14 @@ class SafeController extends PapiController
         return new SectionResults('Query Parameter Removals', $errors);
     }
 
-    public function checkHeaderRemovals($last_array, $current_array)
+    public function checkHeaderRemovals($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
             // do the headers match?
-            $error = $this->operationParametersDiff($last_array, $current_array, $operation_key, 'header');
+            $error = $this->operationParametersDiff($last_open_api, $current_open_api, $operation_key, 'header');
             if ($error) {
                 $errors[] = $error;
             }
@@ -374,16 +374,16 @@ class SafeController extends PapiController
         return new SectionResults('Request Body Property Type Changes', $errors);
     }
 
-    public function checkQueryParameterTypeChanged($last_array, $current_array)
+    public function checkQueryParameterTypeChanged($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
             // are the query parameter types the same?
             $diff_errors = $this->operationParametersTypeDiff(
-                $last_array,
-                $current_array,
+                $last_open_api,
+                $current_open_api,
                 $operation_key,
                 'query',
                 '[schema][type]'
@@ -395,16 +395,16 @@ class SafeController extends PapiController
         return new SectionResults('Query Parameter Type Changes', $errors);
     }
 
-    public function checkHeaderTypeChanged($last_array, $current_array)
+    public function checkHeaderTypeChanged($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
             // are the header types the same?
             $diff_errors = $this->operationParametersTypeDiff(
-                $last_array,
-                $current_array,
+                $last_open_api,
+                $current_open_api,
                 $operation_key,
                 'header',
                 '[schema][type]'
@@ -519,15 +519,15 @@ class SafeController extends PapiController
         return new SectionResults('Request Body Property Optionality', $errors);
     }
 
-    public function checkQueryParameterNowRequired($last_array, $current_array)
+    public function checkQueryParameterNowRequired($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
             $diff_errors = $this->operationParametersRequiredDiff(
-                $last_array,
-                $current_array,
+                $last_open_api,
+                $current_open_api,
                 $operation_key,
                 'query',
                 '[required]'
@@ -539,15 +539,15 @@ class SafeController extends PapiController
         return new SectionResults('Query Parameter Optionality', $errors);
     }
 
-    public function checkHeaderNowRequired($last_array, $current_array)
+    public function checkHeaderNowRequired($last_open_api, $current_open_api)
     {
         $errors = [];
 
         // for matching operations...
-        foreach (PapiMethods::matchingOperationKeys($last_array, $current_array) as $operation_key) {
+        foreach (PapiMethods::matchingOperationKeys($last_open_api, $current_open_api) as $operation_key) {
             $diff_errors = $this->operationParametersRequiredDiff(
-                $last_array,
-                $current_array,
+                $last_open_api,
+                $current_open_api,
                 $operation_key,
                 'header',
                 '[required]'
@@ -802,22 +802,32 @@ class SafeController extends PapiController
         return $operation_parameters;
     }
 
-    public function operationDiff($a_array, $b_array, $on_property, $subject)
+    public function operationDiff($a_open_api, $b_open_api, $on_property, $subject)
     {
         $errors = [];
 
-        $matching_keys = iterator_to_array(PapiMethods::matchingOperationKeys($a_array, $b_array));
+        $matching_operation_keys = iterator_to_array(PapiMethods::matchingOperationKeys($a_open_api, $b_open_api));
 
-        $a_operations = array_filter($matching_keys, function ($operation_key) use ($a_array, $on_property) {
-            $property_value = PapiMethods::getNestedValue($a_array, $operation_key.'['.$on_property.']');
+        $a_operations = array_filter($matching_operation_keys, function ($operation_key) use ($a_open_api, $on_property) {
+            $operation = PapiMethods::getOperation($a_open_api, $operation_key);
+            $operation_object = PapiMethods::objectToArray($operation->getSerializableData());
 
-            return $property_value !== true;
+            if (isset($operation_object[$on_property])) {
+                return $operation_object[$on_property] !== true;
+            } else {
+                return true;
+            }
         });
 
-        $b_operations = array_filter($matching_keys, function ($operation_key) use ($b_array, $on_property) {
-            $property_value = PapiMethods::getNestedValue($b_array, $operation_key.'['.$on_property.']');
+        $b_operations = array_filter($matching_operation_keys, function ($operation_key) use ($b_open_api, $on_property) {
+            $operation = PapiMethods::getOperation($b_open_api, $operation_key);
+            $operation_object = PapiMethods::objectToArray($operation->getSerializableData());
 
-            return $property_value !== true;
+            if (isset($operation_object[$on_property])) {
+                return $operation_object[$on_property] !== true;
+            } else {
+                return true;
+            }
         });
 
         $diff = array_diff($a_operations, $b_operations);

--- a/app/Methods/PapiMethods.php
+++ b/app/Methods/PapiMethods.php
@@ -6,10 +6,13 @@ use Exception;
 use cebe\openapi\Reader;
 use RecursiveArrayIterator;
 use cebe\openapi\spec\OpenApi;
-use cebe\openapi\spec\Operation;
-use cebe\openapi\spec\Response;
 use RecursiveIteratorIterator;
+use cebe\openapi\spec\Response;
+use cebe\openapi\spec\Operation;
+use cebe\openapi\SpecBaseObject;
 use Symfony\Component\Yaml\Yaml;
+use cebe\openapi\spec\RequestBody;
+use cebe\openapi\spec\Schema;
 
 class PapiMethods
 {
@@ -304,7 +307,7 @@ class PapiMethods
             $path = $key_path[1];
             $operation = $key_path[2];
 
-            if ($b_open_api->paths[$path]->getOperations()[$operation]) {
+            if (isset($b_open_api->paths[$path]->getOperations()[$operation])) {
                 yield $operation_key;
             }
         }
@@ -315,26 +318,29 @@ class PapiMethods
         $key_path = explode('][', trim($operation_key, '[]'));
         $path = $key_path[1];
         $operation = $key_path[2];
-        $operation_object = $open_api->paths[$path]->getOperations()[$operation];
+        return $open_api->paths[$path]->getOperations()[$operation];
+    }
 
-        if ($operation_object !== null) {
-            return $operation_object;
-        } else {
-            return null;
-        }
+    public static function getOperationRequestBody($open_api, $operation_key): ?RequestBody
+    {
+        return PapiMethods::getOperation($open_api, $operation_key)->requestBody;
     }
 
     public static function getOperationResponse($open_api, $operation_key, $status_code): ?Response
     {
-        $key_path = explode('][', trim($operation_key, '[]'));
-        $path = $key_path[1];
-        $operation = $key_path[2];
-        $response_object = $open_api->paths[$path]->getOperations()[$operation]->responses[$status_code];
+        return PapiMethods::getOperation($open_api, $operation_key)->responses[$status_code];
+    }
 
-        if ($response_object !== null) {
-            return $response_object;
+    public static function getSchemaArrayFromSpecObject(?SpecBaseObject $object)
+    {
+        if ($object !== null) {
+            $schema = [];
+            if (isset($object->content['application/json'])) {
+                $schema = $object->content['application/json']->getSerializableData()->schema;
+            }
+            return PapiMethods::objectToArray($schema);
         } else {
-            return null;
+            return [];
         }
     }
 

--- a/app/Methods/PapiMethods.php
+++ b/app/Methods/PapiMethods.php
@@ -7,6 +7,7 @@ use cebe\openapi\Reader;
 use RecursiveArrayIterator;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Operation;
+use cebe\openapi\spec\Response;
 use RecursiveIteratorIterator;
 use Symfony\Component\Yaml\Yaml;
 
@@ -236,6 +237,18 @@ class PapiMethods
      * Misc
      */
 
+    public static function objectToArray($object)
+    {
+        if (is_array($object) || is_object($object)) {
+            $result = [];
+            foreach ($object as $key => $value) {
+                $result[$key] = (is_array($object) || is_object($object)) ? PapiMethods::objectToArray($value) : $value;
+            }
+            return $result;
+        }
+        return $object;
+    }
+    
     public static function printOpenApi($open_api)
     {
         foreach ($open_api->paths as $path => $pathItem) {
@@ -306,6 +319,20 @@ class PapiMethods
 
         if ($operation_object !== null) {
             return $operation_object;
+        } else {
+            return null;
+        }
+    }
+
+    public static function getOperationResponse($open_api, $operation_key, $status_code): ?Response
+    {
+        $key_path = explode('][', trim($operation_key, '[]'));
+        $path = $key_path[1];
+        $operation = $key_path[2];
+        $response_object = $open_api->paths[$path]->getOperations()[$operation]->responses[$status_code];
+
+        if ($response_object !== null) {
+            return $response_object;
         } else {
             return null;
         }

--- a/app/Methods/PapiMethods.php
+++ b/app/Methods/PapiMethods.php
@@ -2,7 +2,11 @@
 
 namespace App\Methods;
 
+use Exception;
+use cebe\openapi\Reader;
 use RecursiveArrayIterator;
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Operation;
 use RecursiveIteratorIterator;
 use Symfony\Component\Yaml\Yaml;
 
@@ -93,6 +97,25 @@ class PapiMethods
     /*
      * I/O
      */
+
+    public static function readSpecFileToOpenApi($file_path): ?OpenApi
+    {
+        if (file_exists($file_path)) {
+            try {
+                switch (strtolower(pathinfo($file_path, PATHINFO_EXTENSION))) {
+                case 'json':
+                    return Reader::readFromJsonFile($file_path);
+                case 'yml':
+                case 'yaml':
+                    return Reader::readFromYamlFile($file_path);
+                }
+            } catch (Exception $e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
 
     public static function readSpecFile($file_path)
     {
@@ -213,9 +236,39 @@ class PapiMethods
      * Misc
      */
 
-    public static function formatRouteKey($route_key)
+    public static function printOpenApi($open_api)
     {
-        $trimmed_key = substr($route_key, 1, -1);
+        foreach ($open_api->paths as $path => $pathItem) {
+            echo('Path: ' . $path);
+            echo(PHP_EOL);
+
+            $path_params = $pathItem->parameters;
+            if (count($path_params) > 0) {
+                echo('Path Parameters: ');
+                echo(PHP_EOL);
+            }
+            foreach ($path_params as $param) {
+                echo('- ' . $param->name . ': ' . $param->description);
+                echo(PHP_EOL);
+            }
+
+            foreach ($pathItem->getOperations() as $key => $operation) {
+                echo($key . ': ' . $operation->description);
+                echo(PHP_EOL);
+
+                foreach ($operation->parameters as $parameter) {
+                    echo('- ' . $parameter->name . ': ' . $parameter->description);
+                    echo(PHP_EOL);
+                }
+            }
+
+            echo(PHP_EOL);
+        }
+    }
+
+    public static function formatOperationKey($operation_key)
+    {
+        $trimmed_key = substr($operation_key, 1, -1);
         $parts = explode('][', $trimmed_key);
 
         return strtoupper($parts[2]).' '.$parts[1];
@@ -229,15 +282,32 @@ class PapiMethods
         return join('.', array_slice($parts, 4));
     }
 
-    public static function matchingRouteKeys($a_array, $b_array)
+    public static function matchingOperationKeys($a_open_api, $b_open_api)
     {
-        $a_routes = PapiMethods::routesFromArray($a_array, true);
+        $a_operations = PapiMethods::operationKeysFromOpenApi($a_open_api, true);
 
-        foreach ($a_routes as $route_key) {
-            // is the route also in b?
-            if (PapiMethods::getNestedValue($b_array, $route_key)) {
-                yield $route_key;
+        foreach ($a_operations as $operation_key) {
+            $key_path = explode('][', trim($operation_key, '[]'));
+            $path = $key_path[1];
+            $operation = $key_path[2];
+
+            if ($b_open_api->paths[$path]->getOperations()[$operation]) {
+                yield $operation_key;
             }
+        }
+    }
+
+    public static function getOperation($open_api, $operation_key): ?Operation
+    {
+        $key_path = explode('][', trim($operation_key, '[]'));
+        $path = $key_path[1];
+        $operation = $key_path[2];
+        $operation_object = $open_api->paths[$path]->getOperations()[$operation];
+
+        if ($operation_object !== null) {
+            return $operation_object;
+        } else {
+            return null;
         }
     }
 
@@ -271,41 +341,40 @@ class PapiMethods
         return $models;
     }
 
-    public static function routes($spec_file_path)
+    public static function operationsKeys($spec_file_path)
     {
         $array = PapiMethods::readSpecFile($spec_file_path);
-        return PapiMethods::routesFromArray($array);
+        return PapiMethods::operationKeysFromOpenApi($array);
     }
 
-    public static function routesFromArray($array, $path_format = false)
+    public static function operationKeysFromOpenApi($open_api, $path_format = false)
     {
-        $routes = [];
+        $operations = [];
 
-        if (isset($array['paths'])) {
-            $valid_methods = ['get', 'head', 'post', 'put', 'delete', 'connect', 'options', 'trace', 'patch'];
+        $valid_methods = ['get', 'head', 'post', 'put', 'delete', 'connect', 'options', 'trace', 'patch'];
 
-            // for each path...
-            foreach ($array['paths'] as $path_key => $path) {
-                // for each method...
-                foreach ($path as $method_key => $method) {
-                    if (in_array($method_key, $valid_methods, true)) {
-                        if ($path_format) {
-                            $key_and_value = '[paths]['.$path_key.']['.$method_key.']';
-                            if (!isset($routes[$key_and_value])) {
-                                $routes[$key_and_value] = $key_and_value;
-                            }
-                        } else {
-                            $key_and_value = strtoupper($method_key).' '.$path_key;
-                            if (!isset($routes[$key_and_value])) {
-                                $routes[$key_and_value] = $key_and_value;
-                            }
+        // for each path...
+        foreach ($open_api->paths as $path_key => $pathItem) {
+            // for each method...
+            foreach ($pathItem->getOperations() as $method_key => $operationItem) {
+                if (in_array($method_key, $valid_methods, true)) {
+                    if ($path_format) {
+                        $key_and_value = '[paths]['.$path_key.']['.$method_key.']';
+                        if (!isset($operations[$key_and_value])) {
+                            $operations[$key_and_value] = $key_and_value;
+                        }
+                    } else {
+                        $key_and_value = strtoupper($method_key).' '.$path_key;
+                        if (!isset($operations[$key_and_value])) {
+                            $operations[$key_and_value] = $key_and_value;
                         }
                     }
                 }
             }
         }
 
-        return $routes;
+
+        return $operations;
     }
 
     public static function getNestedValue($array, $key_path)

--- a/app/Methods/PapiMethods.php
+++ b/app/Methods/PapiMethods.php
@@ -376,7 +376,7 @@ class PapiMethods
 
     public static function operationsKeys($spec_file_path)
     {
-        $array = PapiMethods::readSpecFile($spec_file_path);
+        $array = PapiMethods::readSpecFileToOpenApi($spec_file_path);
         return PapiMethods::operationKeysFromOpenApi($array);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
   },
   "require": {
     "php": "^8.0",
+    "cebe/php-openapi": "^1.5",
     "minicli/minicli": "^2.0",
     "symfony/yaml": "^5.3"
   },

--- a/tests/PapiMethodsMiscTest.php
+++ b/tests/PapiMethodsMiscTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use App\Methods\PapiMethods;
+use cebe\openapi\spec\OpenApi;
 use PHPUnit\Framework\TestCase;
 
 class PapiMethodsMiscTest extends TestCase
@@ -40,7 +41,12 @@ class PapiMethodsMiscTest extends TestCase
 
     public function testMatchingOperationKeys()
     {
-        $array_a = [
+        $openapi_a = new OpenApi([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test API',
+                'version' => '1.0.0',
+            ],
             'paths' => [
                 '/hello' => [
                     'get' => [
@@ -48,9 +54,14 @@ class PapiMethodsMiscTest extends TestCase
                     ]
                 ]
             ]
-        ];
+        ]);
 
-        $array_b = [
+        $openapi_b = new OpenApi([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test API',
+                'version' => '1.0.0',
+            ],
             'paths' => [
                 '/hello' => [
                     'get' => [
@@ -63,11 +74,11 @@ class PapiMethodsMiscTest extends TestCase
                     ]
                 ]
             ]
-        ];
-
+        ]);
+        
         $results = [];
 
-        foreach (PapiMethods::matchingOperationKeys($array_a, $array_b) as $index => $result) {
+        foreach (PapiMethods::matchingOperationKeys($openapi_a, $openapi_b) as $index => $result) {
             $results[] = $result;
         }
 
@@ -118,9 +129,14 @@ class PapiMethodsMiscTest extends TestCase
         $this->assertNotContains('GET /listing', $results);
     }
 
-    public function testOperationsFromArray()
+    public function testOperationsFromOpenApi()
     {
-        $array = [
+        $openapi = new OpenApi([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test API',
+                'version' => '1.0.0',
+            ],
             'paths' => [
                 '/hello' => [
                     'get' => [
@@ -133,9 +149,9 @@ class PapiMethodsMiscTest extends TestCase
                     ]
                 ]
             ]
-        ];
+        ]);
 
-        $results = PapiMethods::operationsFromArray($array);
+        $results = PapiMethods::operationKeysFromOpenApi($openapi);
 
         $this->assertCount(2, $results);
         $this->assertContains('GET /hello', $results);

--- a/tests/PapiMethodsMiscTest.php
+++ b/tests/PapiMethodsMiscTest.php
@@ -15,16 +15,16 @@ class PapiMethodsMiscTest extends TestCase
         $this->papi_dir = getcwd();
     }
 
-    public function testFormatRouteKey()
+    public function testFormatOperationKey()
     {
         $this->assertEquals(
             'GET /hello',
-            PapiMethods::formatRouteKey('[paths][/hello][get]')
+            PapiMethods::formatOperationKey('[paths][/hello][get]')
         );
 
         $this->assertEquals(
             'GET /disc/{disc_id}',
-            PapiMethods::formatRouteKey('[paths][/disc/{disc_id}][get]')
+            PapiMethods::formatOperationKey('[paths][/disc/{disc_id}][get]')
         );
     }
 
@@ -38,7 +38,7 @@ class PapiMethodsMiscTest extends TestCase
         );
     }
 
-    public function testMatchingRouteKeys()
+    public function testMatchingOperationKeys()
     {
         $array_a = [
             'paths' => [
@@ -67,7 +67,7 @@ class PapiMethodsMiscTest extends TestCase
 
         $results = [];
 
-        foreach (PapiMethods::matchingRouteKeys($array_a, $array_b) as $index => $result) {
+        foreach (PapiMethods::matchingOperationKeys($array_a, $array_b) as $index => $result) {
             $results[] = $result;
         }
 
@@ -107,18 +107,18 @@ class PapiMethodsMiscTest extends TestCase
         $this->assertNotContains('2021-07-24/Order', $results);
     }
 
-    public function testRoutes()
+    public function testOperations()
     {
         $spec_file = $this->papi_dir.'/examples/reference/PetStore/PetStore.2021-07-23.json';
 
-        $results = PapiMethods::routes($spec_file);
+        $results = PapiMethods::operationsKeys($spec_file);
 
         $this->assertCount(19, $results);
         $this->assertContains('PUT /pet', $results);
         $this->assertNotContains('GET /listing', $results);
     }
 
-    public function testRoutesFromArray()
+    public function testOperationsFromArray()
     {
         $array = [
             'paths' => [
@@ -135,7 +135,7 @@ class PapiMethodsMiscTest extends TestCase
             ]
         ];
 
-        $results = PapiMethods::routesFromArray($array);
+        $results = PapiMethods::operationsFromArray($array);
 
         $this->assertCount(2, $results);
         $this->assertContains('GET /hello', $results);


### PR DESCRIPTION
This handles opening specs with circular references so we can keep moving forward with more complex API development.